### PR TITLE
5

### DIFF
--- a/.0pdd.yml
+++ b/.0pdd.yml
@@ -1,0 +1,10 @@
+errors:
+  - 280603max@gmail.com
+alerts:
+  suppress:
+    - on-found-puzzle
+    - on-lost-puzzle
+    - on-scope
+tags:
+  - bug
+  - pdd


### PR DESCRIPTION
This pull request solves #5 . Configuration file for `0pdd` was set up. No notifications are sent when new puzzles appear, but all error reports are sent to a specified email. On found puzzle `bug` and `pdd` badges are added to the newly created issue.